### PR TITLE
Make dataset location configurable

### DIFF
--- a/api/ai_recommender.py
+++ b/api/ai_recommender.py
@@ -1,10 +1,16 @@
+from pathlib import Path
+import os
+
 from sentence_transformers import SentenceTransformer
 import faiss
 import pandas as pd
 
 model = SentenceTransformer("all-MiniLM-L6-v2")
 
-df = pd.read_csv("data/processed/family_friendly_dataset.csv")
+DEFAULT_DATASET_PATH = Path(__file__).resolve().parents[1] / "data" / "processed" / "family_friendly_dataset.csv"
+DATASET_URL = os.getenv("FAMILY_DATASET_URL", str(DEFAULT_DATASET_PATH))
+
+df = pd.read_csv(DATASET_URL)
 embeddings = model.encode(df["name"].fillna("").tolist(), convert_to_numpy=True)
 index = faiss.IndexFlatL2(embeddings.shape[1])
 index.add(embeddings)

--- a/api/server.py
+++ b/api/server.py
@@ -1,8 +1,10 @@
+import os
+from pathlib import Path
+
+import pandas as pd
 from fastapi import FastAPI, Depends, HTTPException
 from fastapi.security import APIKeyHeader, OAuth2PasswordBearer
 from jose import JWTError, jwt
-import pandas as pd
-import os
 
 API_KEY = os.getenv("FAMILY_API_KEY", "supersecretkey")
 api_key_header = APIKeyHeader(name="X-API-Key", auto_error=False)
@@ -19,7 +21,8 @@ if FIREBASE_PROJECT_ID:
         cred = credentials.ApplicationDefault()
         firebase_admin.initialize_app(cred, {"projectId": FIREBASE_PROJECT_ID})
 
-DATA_URL = "https://raw.githubusercontent.com/yourusername/family-friendly-dataset/main/data/processed/family_friendly_dataset.csv"
+DEFAULT_DATASET_PATH = Path(__file__).resolve().parents[1] / "data" / "processed" / "family_friendly_dataset.csv"
+DATA_URL = os.getenv("FAMILY_DATASET_URL", str(DEFAULT_DATASET_PATH))
 USE_BIGQUERY = os.getenv("USE_BIGQUERY", "false").lower() == "true"
 
 if USE_BIGQUERY:
@@ -28,7 +31,10 @@ if USE_BIGQUERY:
     bq_client = bigquery.Client()
 
 def load_dataset():
-    return pd.read_csv(DATA_URL)
+    try:
+        return pd.read_csv(DATA_URL)
+    except Exception as exc:
+        raise HTTPException(status_code=500, detail=f"Failed to load dataset from {DATA_URL}") from exc
 
 def verify_api_key(api_key: str = Depends(api_key_header)):
     if api_key != API_KEY:


### PR DESCRIPTION
## Summary
- allow the recommender and API to read the dataset path from the FAMILY_DATASET_URL environment variable
- provide a default path relative to the repository so local runs keep working and report clear errors when the dataset cannot be loaded

## Testing
- `python -m compileall api`


------
https://chatgpt.com/codex/tasks/task_e_68c879f46e6c8321a25dcadba3e88d4f