### PR TITLE
Handle missing spaCy model gracefully

### DIFF
--- a/bots/nlu_parser.py
+++ b/bots/nlu_parser.py
@@ -1,6 +1,17 @@
+from functools import lru_cache
+
 import spacy
 
-nlp = spacy.load("en_core_web_sm")
+
+@lru_cache(maxsize=1)
+def get_nlp():
+    try:
+        return spacy.load("en_core_web_sm")
+    except OSError as exc:
+        raise OSError(
+            "The spaCy model 'en_core_web_sm' is required. "
+            "Install it with `python -m spacy download en_core_web_sm`."
+        ) from exc
 
 STATES = {
     "california": "CA", "texas": "TX", "florida": "FL", "new york": "NY",
@@ -8,7 +19,7 @@ STATES = {
 }
 
 def parse_query(text: str):
-    doc = nlp(text.lower())
+    doc = get_nlp()(text.lower())
     state, indoor, price, category = None, None, None, None
 
     if "indoor" in text:


### PR DESCRIPTION
## Summary
- cache spaCy model loading and reuse it when parsing queries
- provide a clear error message instructing users to install `en_core_web_sm` if the model is missing

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68c879f2ffd88321b97c4711223aee41