### PR TITLE
Lazy load AI recommender resources via env configuration

### DIFF
--- a/api/ai_recommender.py
+++ b/api/ai_recommender.py
@@ -1,16 +1,41 @@
-from sentence_transformers import SentenceTransformer
+import os
+
 import faiss
 import pandas as pd
+from sentence_transformers import SentenceTransformer
 
-model = SentenceTransformer("all-MiniLM-L6-v2")
+DATASET_PATH_ENV_VAR = "FAMILY_FRIENDLY_DATASET_PATH"
 
-df = pd.read_csv("data/processed/family_friendly_dataset.csv")
-embeddings = model.encode(df["name"].fillna("").tolist(), convert_to_numpy=True)
-index = faiss.IndexFlatL2(embeddings.shape[1])
-index.add(embeddings)
+_model = None
+_df = None
+_index = None
+
+
+def _initialize():
+    global _model, _df, _index
+    if _model is not None and _df is not None and _index is not None:
+        return
+
+    dataset_path = os.environ.get(DATASET_PATH_ENV_VAR)
+    if not dataset_path:
+        raise RuntimeError(
+            f"Environment variable {DATASET_PATH_ENV_VAR} must be set to the dataset CSV path."
+        )
+
+    _model = SentenceTransformer("all-MiniLM-L6-v2")
+    _df = pd.read_csv(dataset_path)
+
+    embeddings = _model.encode(
+        _df["name"].fillna("").tolist(), convert_to_numpy=True
+    )
+    _index = faiss.IndexFlatL2(embeddings.shape[1])
+    _index.add(embeddings)
+
 
 def semantic_search(query, top_k=5):
-    q_vec = model.encode([query], convert_to_numpy=True)
-    distances, indices = index.search(q_vec, top_k)
-    results = df.iloc[indices[0]].to_dict(orient="records")
+    _initialize()
+
+    q_vec = _model.encode([query], convert_to_numpy=True)
+    distances, indices = _index.search(q_vec, top_k)
+    results = _df.iloc[indices[0]].to_dict(orient="records")
     return results


### PR DESCRIPTION
## Summary
- Lazily initialize the SentenceTransformer model, dataset, and FAISS index on first use
- Configure the dataset location through the `FAMILY_FRIENDLY_DATASET_PATH` environment variable with a clear error when missing

## Testing
- `python -m compileall api/ai_recommender.py`


------
https://chatgpt.com/codex/tasks/task_e_68c879f0c24c8321802a227d40fd837c