### PR TITLE
Copy entire API directory in Docker build

### DIFF
--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -1,12 +1,8 @@
 FROM python:3.10-slim
 
+COPY api/ /app/
 WORKDIR /app
-
-COPY api/server.py /app/server.py
-COPY api/requirements.txt /app/requirements.txt
-
-RUN pip install --no-cache-dir -r requirements.txt
+RUN pip install --no-cache-dir -r /app/requirements.txt
 
 EXPOSE 8000
-
 CMD ["uvicorn", "server:app", "--host", "0.0.0.0", "--port", "8000"]


### PR DESCRIPTION
## Summary
- copy the entire API directory into the Docker image to include all modules
- set the workdir to /app and install dependencies from the copied requirements file

## Testing
- not run (Dockerfile change only)


------
https://chatgpt.com/codex/tasks/task_e_68c879ef869083219955d06ac2ad6f5a