### PR TITLE
Allow configuring dataset source

### DIFF
--- a/api/ai_recommender.py
+++ b/api/ai_recommender.py
@@ -1,10 +1,23 @@
+import os
+from pathlib import Path
+
 from sentence_transformers import SentenceTransformer
 import faiss
 import pandas as pd
 
+
+def _resolve_data_source() -> str:
+    """Return the configured dataset source as a path or URL."""
+    configured_source = os.getenv("FAMILY_DATA_SOURCE") or os.getenv("FAMILY_DATA_URL")
+    if configured_source:
+        return configured_source
+
+    default_path = Path(__file__).resolve().parents[1] / "data/processed/family_friendly_dataset.csv"
+    return str(default_path)
+
 model = SentenceTransformer("all-MiniLM-L6-v2")
 
-df = pd.read_csv("data/processed/family_friendly_dataset.csv")
+df = pd.read_csv(_resolve_data_source())
 embeddings = model.encode(df["name"].fillna("").tolist(), convert_to_numpy=True)
 index = faiss.IndexFlatL2(embeddings.shape[1])
 index.add(embeddings)


### PR DESCRIPTION
## Summary
- allow the semantic search pipeline to load its dataset from a configurable source
- update the API server to resolve the dataset location via environment variables or a local default

## Testing
- python -m compileall api

------
https://chatgpt.com/codex/tasks/task_e_68c877e9310c83218c367cbe889e989f