### PR TITLE
Add missing closing tags to index page

### DIFF
--- a/index.html
+++ b/index.html
@@ -59,3 +59,16 @@
       <a href="#">Destinations</a>
       <a href="#">Contact</a>
     </nav>
+  </header>
+  <main>
+    <h1>Explore family-friendly adventures</h1>
+    <p>
+      Discover curated destinations, itineraries, and tips to make your next trip
+      unforgettable.
+    </p>
+  </main>
+  <footer>
+    <p>&copy; 2024 Scout Fox Travel. All rights reserved.</p>
+  </footer>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add the missing closing structure for the header, body, and html tags on the landing page
- provide minimal main and footer content so the page renders complete markup

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68c877e693d88321bdf867b24cb08648