### PR TITLE
Improve spaCy model loading

### DIFF
--- a/bots/nlu_parser.py
+++ b/bots/nlu_parser.py
@@ -1,6 +1,20 @@
+from functools import lru_cache
+
 import spacy
 
-nlp = spacy.load("en_core_web_sm")
+
+@lru_cache(maxsize=1)
+def load_spacy_model():
+    try:
+        return spacy.load("en_core_web_sm")
+    except OSError as exc:
+        raise RuntimeError(
+            "The spaCy English model 'en_core_web_sm' is required. "
+            "Install it with `python -m spacy download en_core_web_sm`."
+        ) from exc
+
+
+nlp = load_spacy_model()
 
 STATES = {
     "california": "CA", "texas": "TX", "florida": "FL", "new york": "NY",


### PR DESCRIPTION
## Summary
- wrap spaCy model loading in a helper that caches the model
- raise a clear error instructing users to install `en_core_web_sm` when the model is missing

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68c877e3d8cc8321bd244aad5f61c9e5