### PR TITLE
Simplify API Dockerfile copy step

### DIFF
--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -1,9 +1,8 @@
 FROM python:3.10-slim
 
-WORKDIR /app
+COPY api/ /app/
 
-COPY api/server.py /app/server.py
-COPY api/requirements.txt /app/requirements.txt
+WORKDIR /app
 
 RUN pip install --no-cache-dir -r requirements.txt
 


### PR DESCRIPTION
## Summary
- copy the entire API directory into /app during the build
- set the working directory after the copy so pip installs from the copied files

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68c877de963c83219a4789a603b844b8