### PR TITLE
Allow configuring dataset source via environment variable

### DIFF
--- a/api/ai_recommender.py
+++ b/api/ai_recommender.py
@@ -1,10 +1,27 @@
-from sentence_transformers import SentenceTransformer
+import os
+from functools import lru_cache
+
 import faiss
 import pandas as pd
+from sentence_transformers import SentenceTransformer
+
+DEFAULT_DATA_SOURCE = "https://raw.githubusercontent.com/yourusername/family-friendly-dataset/main/data/processed/family_friendly_dataset.csv"
+DATA_SOURCE = os.getenv("FAMILY_DATA_URL", DEFAULT_DATA_SOURCE)
+
+
+@lru_cache(maxsize=1)
+def load_dataset():
+    try:
+        return pd.read_csv(DATA_SOURCE)
+    except FileNotFoundError as exc:
+        raise FileNotFoundError(
+            f"Dataset not found at '{DATA_SOURCE}'. "
+            "Set the FAMILY_DATA_URL environment variable to a valid path or URL."
+        ) from exc
 
 model = SentenceTransformer("all-MiniLM-L6-v2")
 
-df = pd.read_csv("data/processed/family_friendly_dataset.csv")
+df = load_dataset()
 embeddings = model.encode(df["name"].fillna("").tolist(), convert_to_numpy=True)
 index = faiss.IndexFlatL2(embeddings.shape[1])
 index.add(embeddings)


### PR DESCRIPTION
## Summary
- allow the recommender and API server to load the dataset from a configurable FAMILY_DATA_URL environment variable
- cache dataset loading and provide helpful error messaging when the source is missing

## Testing
- python -m compileall api

------
https://chatgpt.com/codex/tasks/task_e_68c875e7e4908321a9d00a0cc5011f07