### PR TITLE
Lazy-load AI recommender resources and configure dataset path

### DIFF
--- a/api/ai_recommender.py
+++ b/api/ai_recommender.py
@@ -1,16 +1,47 @@
+import os
+
 from sentence_transformers import SentenceTransformer
 import faiss
 import pandas as pd
 
-model = SentenceTransformer("all-MiniLM-L6-v2")
 
-df = pd.read_csv("data/processed/family_friendly_dataset.csv")
-embeddings = model.encode(df["name"].fillna("").tolist(), convert_to_numpy=True)
-index = faiss.IndexFlatL2(embeddings.shape[1])
-index.add(embeddings)
+_DATASET_ENV_VAR = "FAMILY_FRIENDLY_DATASET_PATH"
+
+_model = None
+_index = None
+_df = None
+
+
+def _initialize():
+    """Lazily load the model, dataset, and FAISS index."""
+    global _model, _index, _df
+
+    if _model is not None:
+        return
+
+    dataset_path = os.getenv(_DATASET_ENV_VAR)
+    if not dataset_path:
+        raise RuntimeError(
+            f"Environment variable {_DATASET_ENV_VAR} must be set to the dataset CSV path."
+        )
+
+    if not os.path.exists(dataset_path):
+        raise FileNotFoundError(
+            f"Dataset file specified by {_DATASET_ENV_VAR} does not exist: {dataset_path}"
+        )
+
+    _model = SentenceTransformer("all-MiniLM-L6-v2")
+
+    _df = pd.read_csv(dataset_path)
+    embeddings = _model.encode(_df["name"].fillna("").tolist(), convert_to_numpy=True)
+    _index = faiss.IndexFlatL2(embeddings.shape[1])
+    _index.add(embeddings)
+
 
 def semantic_search(query, top_k=5):
-    q_vec = model.encode([query], convert_to_numpy=True)
-    distances, indices = index.search(q_vec, top_k)
-    results = df.iloc[indices[0]].to_dict(orient="records")
+    _initialize()
+
+    q_vec = _model.encode([query], convert_to_numpy=True)
+    distances, indices = _index.search(q_vec, top_k)
+    results = _df.iloc[indices[0]].to_dict(orient="records")
     return results


### PR DESCRIPTION
## Summary
- lazily initialize the SentenceTransformer model, dataset, and FAISS index on first use
- require the dataset CSV path from the FAMILY_FRIENDLY_DATASET_PATH environment variable with clear error messaging
- rebuild the FAISS index during initialization and reuse it for semantic search calls

## Testing
- python -m compileall api/ai_recommender.py

------
https://chatgpt.com/codex/tasks/task_e_68c875e341648321b6853520968a4d25