### PR TITLE
Ensure DATA_URL uses single-line URL

### DIFF
--- a/api/server.py
+++ b/api/server.py
@@ -19,6 +19,7 @@ if FIREBASE_PROJECT_ID:
         cred = credentials.ApplicationDefault()
         firebase_admin.initialize_app(cred, {"projectId": FIREBASE_PROJECT_ID})
 
+# URL of the processed dataset CSV hosted in the repository
 DATA_URL = "https://raw.githubusercontent.com/yourusername/family-friendly-dataset/main/data/processed/family_friendly_dataset.csv"
 USE_BIGQUERY = os.getenv("USE_BIGQUERY", "false").lower() == "true"
 


### PR DESCRIPTION
## Summary
- document the processed dataset URL in `api/server.py` so the single-line constant is easy to verify

## Testing
- python -m compileall api/server.py

------
https://chatgpt.com/codex/tasks/task_e_68c875dee6c883218790138d00efe80a