### PR TITLE
Update API Dockerfile to copy full app directory

### DIFF
--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -1,9 +1,8 @@
 FROM python:3.10-slim
 
-WORKDIR /app
+COPY api/ /app/
 
-COPY api/server.py /app/server.py
-COPY api/requirements.txt /app/requirements.txt
+WORKDIR /app
 
 RUN pip install --no-cache-dir -r requirements.txt
 


### PR DESCRIPTION
## Summary
- copy the entire API folder into the image instead of a single file
- move the working directory definition after copying and run dependency installation from within /app

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68c875e1c2748321b0c1ac72929e620b