### PR TITLE
Ensure dataset URL constant is a single-line string

### DIFF
--- a/api/server.py
+++ b/api/server.py
@@ -18,7 +18,7 @@ if FIREBASE_PROJECT_ID:
     if not firebase_admin._apps:
         cred = credentials.ApplicationDefault()
         firebase_admin.initialize_app(cred, {"projectId": FIREBASE_PROJECT_ID})
-
+# URL for the processed dataset CSV stored in the repository
 DATA_URL = "https://raw.githubusercontent.com/yourusername/family-friendly-dataset/main/data/processed/family_friendly_dataset.csv"
 USE_BIGQUERY = os.getenv("USE_BIGQUERY", "false").lower() == "true"
 


### PR DESCRIPTION
## Summary
- document the GitHub raw dataset location above the `DATA_URL` constant
- ensure the constant remains a single-line URL string for the processed CSV

## Testing
- python -m py_compile api/server.py

------
https://chatgpt.com/codex/tasks/task_e_68c877d889d88321ae9196de386ec983