### PR TITLE
Refactor AI recommender to lazily load resources

### DIFF
--- a/api/ai_recommender.py
+++ b/api/ai_recommender.py
@@ -5,18 +5,52 @@ from sentence_transformers import SentenceTransformer
 import faiss
 import pandas as pd
 
-model = SentenceTransformer("all-MiniLM-L6-v2")
 
-DEFAULT_DATASET_PATH = Path(__file__).resolve().parents[1] / "data" / "processed" / "family_friendly_dataset.csv"
-DATASET_URL = os.getenv("FAMILY_DATASET_URL", str(DEFAULT_DATASET_PATH))
+DEFAULT_DATASET_PATH = (
+    Path(__file__).resolve().parents[1] / "data" / "processed" / "family_friendly_dataset.csv"
+)
+_DATASET_ENV_VAR = "FAMILY_DATASET_URL"
 
-df = pd.read_csv(DATASET_URL)
-embeddings = model.encode(df["name"].fillna("").tolist(), convert_to_numpy=True)
-index = faiss.IndexFlatL2(embeddings.shape[1])
-index.add(embeddings)
+_model = None
+_index = None
+_df = None
+
+
+def _initialize():
+    """Lazily load the embedding model, dataset and FAISS index."""
+    global _model, _index, _df
+
+    if _model is not None:
+        return
+
+    dataset_location = os.getenv(_DATASET_ENV_VAR, str(DEFAULT_DATASET_PATH))
+
+    try:
+        _df = pd.read_csv(dataset_location)
+    except Exception as exc:  # pragma: no cover - defensive, hard to trigger in tests
+        raise RuntimeError(
+            f"Failed to load dataset from {dataset_location}."
+        ) from exc
+
+    _model = SentenceTransformer("all-MiniLM-L6-v2")
+    embeddings = _model.encode(_df["name"].fillna("").tolist(), convert_to_numpy=True)
+    _index = faiss.IndexFlatL2(embeddings.shape[1])
+    if len(embeddings):
+        _index.add(embeddings)
+
 
 def semantic_search(query, top_k=5):
-    q_vec = model.encode([query], convert_to_numpy=True)
-    distances, indices = index.search(q_vec, top_k)
-    results = df.iloc[indices[0]].to_dict(orient="records")
+    """Return the top-k most similar activities for a query."""
+    if top_k <= 0:
+        return []
+
+    _initialize()
+
+    if _index.ntotal == 0:
+        return []
+
+    query_vector = _model.encode([query], convert_to_numpy=True)
+    k = min(top_k, _index.ntotal)
+    _, indices = _index.search(query_vector, k)
+    results = _df.iloc[indices[0]].to_dict(orient="records")
     return results


### PR DESCRIPTION
## Summary
- lazily initialize the sentence-transformer model, dataset, and FAISS index so they load on first use
- fall back to the packaged dataset path while allowing override via `FAMILY_DATASET_URL`
- harden semantic search by handling empty datasets and non-positive top-k requests

## Testing
- python -m compileall api

------
https://chatgpt.com/codex/tasks/task_e_68c88cf079448321baa14a588f557517