### PR TITLE
Updated vercel.json Build Configuration Changes

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,8 +1,15 @@
 {
+  "version": 2,
   "builds": [
-    { "src": "public/**/*", "use": "@vercel/static" }
+    {
+      "src": "server.js",
+      "use": "@vercel/node"
+    }
   ],
   "routes": [
-    { "src": "/(.*)", "dest": "/public/$1" }
+    {
+      "src": "/(.*)",
+      "dest": "server.js"
+    }
   ]
 }


### PR DESCRIPTION
The Current Build is facing this conflict issue 

[03:00:40.998] WARN! Due to `builds` existing in your configuration file, the Build and Development Settings defined in your Project Settings will not apply. Learn More: https://vercel.link/unused-build-settings

So we have solved this issue by forcing the code to use the build configurations of the system(Vercel's)
